### PR TITLE
fix(frontend): スクロールバーのカスタムスタイルを削除して横ずれを解消

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -47,14 +47,3 @@ body {
 .route-fade {
 	animation: routeFade 280ms cubic-bezier(0, 0, 0.2, 1);
 }
-
-::-webkit-scrollbar {
-	width: 10px;
-	height: 10px;
-}
-
-::-webkit-scrollbar-thumb {
-	background: var(--color-gray-300);
-	border-radius: 9999px;
-	border: 2px solid #f4f6f9;
-}


### PR DESCRIPTION
## Overview

- ルート遷移時に画面が右へ「がくつく」横ずれが発生していたため、原因となっていた `::-webkit-scrollbar` のカスタムスタイル（幅10px指定）を削除した
- カスタムスクロールバーの10px幅により、ページごとのスクロールバー出現/消失でレイアウト幅が変わり、中央寄せレイアウトが横にずれていた
- ブラウザ標準のスクロールバーに戻すことで、ずれを軽減する