### PR TITLE
chore: Renovate に GitHub Packages 認証設定を追加

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
 	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
 	"extends": ["config:recommended"],
+	"hostRules": [
+		{
+			"matchHost": "npm.pkg.github.com",
+			"hostType": "npm",
+			"token": "{{ secrets.GITHUB_NPM_TOKEN }}"
+		}
+	],
 	"lockFileMaintenance": {
 		"enabled": true
 	},


### PR DESCRIPTION
## Overview

- Renovate が作る依存更新 PR が全て CI で落ちていたため、原因を解消する設定を追加した
- 原因は Renovate が GitHub Packages (`npm.pkg.github.com`) のプライベートパッケージ `@aiharanaoya/ui` に認証できず、`pnpm-lock.yaml` の更新に失敗していたこと（`renovate/artifacts` failure）。結果 lockfile が古いまま PR が作られ、CI の `pnpm i --frozen-lockfile` が弾いていた
- `hostRules` で `npm.pkg.github.com` への認証トークンを指定し、Renovate が lockfile を更新できるようにする
- 動作には Renovate 側に `GITHUB_NPM_TOKEN` シークレット（`read:packages` 権限）の登録が必要